### PR TITLE
feat: TagUnion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+.phpunit.cache/
+vendor/
+composer.lock

--- a/src/Types/Events.php
+++ b/src/Types/Events.php
@@ -49,8 +49,9 @@ final class Events implements IteratorAggregate, JsonSerializable, Countable
     }
 
     /**
-     * @param Closure(Event $event): mixed $callback
-     * @return array<string, mixed>
+     * @template TReturn
+     * @param Closure(Event $event): TReturn $callback
+     * @return array<array-key, TReturn>
      */
     public function map(Closure $callback): array
     {

--- a/src/Types/StreamQuery/Criteria.php
+++ b/src/Types/StreamQuery/Criteria.php
@@ -79,8 +79,9 @@ final class Criteria implements IteratorAggregate, JsonSerializable
     }
 
     /**
-     * @param Closure(EventTypesAndTagsCriterion $criterion): mixed $callback
-     * @return array<string, mixed>
+     * @template TReturn
+     * @param Closure(EventTypesAndTagsCriterion $criterion): TReturn $callback
+     * @return array<array-key, TReturn>
      */
     public function map(Closure $callback): array
     {

--- a/src/Types/TagUnion.php
+++ b/src/Types/TagUnion.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\DCBEventStore\Types;
+
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
+
+/** @implements IteratorAggregate<self|Tag> */
+final readonly class TagUnion implements IteratorAggregate, JsonSerializable
+{
+    public function __construct(public Tags $tags)
+    {
+    }
+
+    public static function create(Tag|Tags ...$tags): self
+    {
+        $allTags = Tags::create();
+
+        foreach ($tags as $tag) {
+            $allTags = $allTags->merge($tag);
+        }
+
+        return new self($allTags);
+    }
+
+    public function toString(): string
+    {
+        return implode('|', $this->tags->toStrings());
+    }
+
+    /** @return array{union: Tags} */
+    public function jsonSerialize(): array
+    {
+        return ['union' => $this->tags];
+    }
+
+    /**
+     * @return Traversable<TagUnion|Tag>
+     */
+    public function getIterator(): Traversable
+    {
+        return $this->tags->getIterator();
+    }
+}


### PR DESCRIPTION
## Features

- **TagUnion** - one hit is enough to match.

### Why

I've found myself in a scenario where my projection for decision model needs to load events which contain at least one tag from a given list.

It cannot be a dedicated `TaggedUnionProjection` for example as overall tags must be matched with `&&`, but only a subset with `||`.

### Example

```php
new TaggedProjection(
    tags: Tags::create(
        $habitId->toTag(),
        match (true) {
            $date instanceof LocalDate => Tag::fromString("date:{$date->toISOString()}"),
            $date instanceof LocalDateRange => TagUnion::create(...array_map(
                fn (LocalDate $dateInRange) => Tag::fromString("date:{$dateInRange->toISOString()}"),
                iterator_to_array($date->getIterator()),
            )),
        },
    ),
    projection: ClosureProjection::create(
        initialState: 0,
        onlyLastEvent: false,
    )
        ->when(RepetitionsCompleted::class, fn (int $state, RepetitionsCompleted $event) => $state + $event->amount)
        ->when(RepetitionsCompletedOnDateRange::class, fn (int $state, RepetitionsCompletedOnDateRange $event) => $state + $event->repetitions->amount)
        ->when(RepetitionsReset::class, fn (int $state, RepetitionsReset $event) => 0)
        ->when(RepetitionsInDateRangeReset::class, fn (int $state, RepetitionsInDateRangeReset $event) => 0),
)
```

### Notes

Whether or not it is ok to tag events with dates is debatable I guess, but I found that it works in my domain 🤷
However, I don't know if this VO is the right approach, so if you have better ideas or think that this should not exist at all, let me know 🙂 

If idea is approved, I will add tests and documentation. Doctrine and Laravel event stores will also need to be updated to support this and I don't know if this doesn't technically count as a breaking change 🤔 

## Chores
- Added .gitignore 
- Fixed some types in phpdocs

### Checklist
- [ ] Tests for TagUnion feature are added.
- [ ] Documentation has been updated as needed.