### PR TITLE
Fix: Run `coding-standards` and `static-code-analysis` jobs on lowest supported PHP version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-         - '8.4'
+          - '8.3'
         dependencies:
           - 'highest'
 
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-         - '8.4'
+          - '8.3'
         dependencies:
           - 'highest'
 


### PR DESCRIPTION
This pull request

- [x] runs the `coding-standards` and `static-code-analysis` jobs on the lowest supported PHP version